### PR TITLE
feat: Add type_support option

### DIFF
--- a/specs/source.go
+++ b/specs/source.go
@@ -34,11 +34,11 @@ type Source struct {
 	Tables []string `json:"tables,omitempty"`
 	// SkipTables defines tables to skip when syncing data. Useful if a glob pattern is used in Tables
 	SkipTables []string `json:"skip_tables,omitempty"`
-	// SkipDependentTables changes the matching behavior with regard to dependent tables. If set to true, dependent tables will not be synced unless they are explicitly matched by Tables.
+	// SkipDependentTables changes the matching behavior with regard to dependent tables. If set to true,
+	// dependent tables will not be synced unless they are explicitly matched by Tables.
 	SkipDependentTables bool `json:"skip_dependent_tables,omitempty"`
 	// Destinations are the names of destination plugins to send sync data to
 	Destinations []string `json:"destinations,omitempty"`
-
 	// Backend is the name of the state backend to use
 	Backend Backend `json:"backend,omitempty"`
 	// BackendSpec contains any backend-specific configuration
@@ -48,15 +48,22 @@ type Source struct {
 	// Spec defines plugin specific configuration
 	// This is different in every source plugin.
 	Spec any `json:"spec,omitempty"`
-
 	// DeterministicCQID is a flag that indicates whether the source plugin should generate a random UUID as the value of _cq_id
 	// or whether it should calculate a UUID that is a hash of the primary keys (if they exist) or the entire resource.
 	DeterministicCQID bool `json:"deterministic_cq_id,omitempty"`
+	// TypeSupport defines whether to use a limited set of types for backwards-compatibility with
+	// CQTypes (used in the original v1 release of CloudQuery), or the full set of types supported by Arrow.
+	TypeSupport TypeSupport `json:"type_support,omitempty"`
 }
 
 func (s *Source) SetDefaults() {
 	if s.Registry.String() == "" {
 		s.Registry = RegistryGithub
+	}
+	if s.TypeSupport.String() == "" {
+		// Default to limited type support for backwards-compatibility.
+		// This default may change in the future.
+		s.TypeSupport = TypeSupportLimited
 	}
 	if s.Backend.String() == "" {
 		s.Backend = BackendNone

--- a/specs/source.go
+++ b/specs/source.go
@@ -62,7 +62,6 @@ func (s *Source) SetDefaults() {
 	}
 	if s.TypeSupport.String() == "" {
 		// Default to limited type support for backwards-compatibility.
-		// This default may change in the future.
 		s.TypeSupport = TypeSupportLimited
 	}
 	if s.Backend.String() == "" {

--- a/specs/type_support.go
+++ b/specs/type_support.go
@@ -1,0 +1,46 @@
+package specs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type TypeSupport int
+
+const (
+	TypeSupportLimited TypeSupport = iota
+	TypeSupportFull
+)
+
+func (r TypeSupport) String() string {
+	return [...]string{"limited", "full"}[r]
+}
+func (r TypeSupport) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(r.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+func (r *TypeSupport) UnmarshalJSON(data []byte) (err error) {
+	var typeSupport string
+	if err := json.Unmarshal(data, &typeSupport); err != nil {
+		return err
+	}
+	if *r, err = TypeSupportFromString(typeSupport); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TypeSupportFromString(s string) (TypeSupport, error) {
+	switch s {
+	case "limited":
+		return TypeSupportLimited, nil
+	case "full":
+		return TypeSupportFull, nil
+	default:
+		return TypeSupportLimited, fmt.Errorf("unknown type support %s", s)
+	}
+}

--- a/specs/type_support_test.go
+++ b/specs/type_support_test.go
@@ -1,0 +1,36 @@
+package specs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestTypeSupportJsonMarshalUnmarshal(t *testing.T) {
+	b, err := json.Marshal(TypeSupportFull)
+	if err != nil {
+		t.Fatal("failed to marshal typeSupport:", err)
+	}
+	var typeSupport TypeSupport
+	if err := json.Unmarshal(b, &typeSupport); err != nil {
+		t.Fatal("failed to unmarshal typeSupport:", err)
+	}
+	if typeSupport != TypeSupportFull {
+		t.Fatal("expected typeSupport to be full, but got:", typeSupport)
+	}
+}
+
+func TestTypeSupportYamlMarshalUnmarsahl(t *testing.T) {
+	b, err := yaml.Marshal(TypeSupportFull)
+	if err != nil {
+		t.Fatal("failed to marshal typeSupport:", err)
+	}
+	var typeSupport TypeSupport
+	if err := yaml.Unmarshal(b, &typeSupport); err != nil {
+		t.Fatal("failed to unmarshal typeSupport:", err)
+	}
+	if typeSupport != TypeSupportFull {
+		t.Fatal("expected typeSupport to be full, but got:", typeSupport)
+	}
+}


### PR DESCRIPTION
This introduces a `type_support` option for source plugins. It can have two values:

 - `limited` (default): only types that were supported in cqtypes will be used. Any types that don't conform will be converted before sending it to the destination plugin. This is backwards-compatible
 - `full`: all available Arrow types will be used, including lists and structs.