### PR TITLE
fix(ci): Create a separate cache key for the lint job

### DIFF
--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -14,8 +14,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
+        id: go
         with:
           go-version-file: go.mod
+          # We use a manually configured cache key to avoid conflicts with the test action cache
+          # See https://github.com/actions/setup-go/issues/358
+          cache: false
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{runner.os}}-go-${{steps.go.outputs.go-version}}-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{runner.os}}-go-${{steps.go.outputs.go-version}}-lint
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Use a manually configured cache key for the lint job, to avoid conflicts with the test job
---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
