### PR TITLE
feat: Add arrow schema encoding to v2

### DIFF
--- a/pb/destination/v1/arrow.go
+++ b/pb/destination/v1/arrow.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	MetadataTableName        = "cq:table_name"
+	MetadataTableName = "cq:table_name"
 )
 
 type Schemas []*arrow.Schema

--- a/pb/destination/v1/arrow.go
+++ b/pb/destination/v1/arrow.go
@@ -1,0 +1,43 @@
+package destination
+
+import (
+	"bytes"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/apache/arrow/go/v13/arrow/ipc"
+)
+
+const (
+	MetadataTableName        = "cq:table_name"
+)
+
+type Schemas []*arrow.Schema
+
+func (s Schemas) Len() int {
+	return len(s)
+}
+
+func (s Schemas) SchemaByName(name string) *arrow.Schema {
+	for _, sc := range s {
+		tableName, ok := sc.Metadata().GetValue(MetadataTableName)
+		if !ok {
+			continue
+		}
+		if tableName == name {
+			return sc
+		}
+	}
+	return nil
+}
+
+func NewSchemasFromBytes(b [][]byte) (Schemas, error) {
+	ret := make([]*arrow.Schema, len(b))
+	for i, buf := range b {
+		rdr, err := ipc.NewReader(bytes.NewReader(buf))
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = rdr.Schema()
+	}
+	return ret, nil
+}

--- a/pb/source/v2/arrow.go
+++ b/pb/source/v2/arrow.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	MetadataTableName        = "cq:table_name"
+	MetadataTableName = "cq:table_name"
 )
 
 type Schemas []*arrow.Schema

--- a/pb/source/v2/arrow.go
+++ b/pb/source/v2/arrow.go
@@ -1,0 +1,44 @@
+package source
+
+import (
+	"bytes"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/apache/arrow/go/v13/arrow/ipc"
+)
+
+const (
+	MetadataTableName        = "cq:table_name"
+)
+
+type Schemas []*arrow.Schema
+
+func (s Schemas) Len() int {
+	return len(s)
+}
+
+func (s Schemas) SchemaByName(name string) *arrow.Schema {
+	for _, sc := range s {
+		tableName, ok := sc.Metadata().GetValue(MetadataTableName)
+		if !ok {
+			continue
+		}
+		if tableName == name {
+			return sc
+		}
+	}
+	return nil
+}
+
+func (s Schemas) Encode() ([][]byte, error) {
+	ret := make([][]byte, len(s))
+	for i, sc := range s {
+		var buf bytes.Buffer
+		wr := ipc.NewWriter(&buf, ipc.WithSchema(sc))
+		if err := wr.Close(); err != nil {
+			return nil, err
+		}
+		ret[i] = buf.Bytes()
+	}
+	return ret, nil
+}


### PR DESCRIPTION
This moves byte encoding/decoding function to be under the right package/version (for old protocol) as they are part of the protocol and cannot change.