### PR TITLE
fix: Add record enc/dec to destv1 sourcev2

### DIFF
--- a/pb/destination/v1/arrow.go
+++ b/pb/destination/v1/arrow.go
@@ -18,3 +18,16 @@ func NewSchemasFromBytes(b [][]byte) ([]*arrow.Schema, error) {
 	}
 	return ret, nil
 }
+
+func NewRecordFromBytes(b []byte) (arrow.Record, error) {
+	rdr, err := ipc.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	for rdr.Next() {
+		rec := rdr.Record()
+		rec.Retain()
+		return rec, nil
+	}
+	return nil, nil
+}

--- a/pb/source/v2/arrow.go
+++ b/pb/source/v2/arrow.go
@@ -19,3 +19,16 @@ func SchemasToBytes(schemas []*arrow.Schema) ([][]byte, error) {
 	}
 	return ret, nil
 }
+
+
+func RecordToBytes(record arrow.Record) ([]byte, error) {
+	var buf bytes.Buffer
+	wr := ipc.NewWriter(&buf, ipc.WithSchema(record.Schema()))
+	if err := wr.Write(record); err != nil {
+		return nil, err
+	}
+	if err := wr.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pb/source/v2/arrow.go
+++ b/pb/source/v2/arrow.go
@@ -20,7 +20,6 @@ func SchemasToBytes(schemas []*arrow.Schema) ([][]byte, error) {
 	return ret, nil
 }
 
-
 func RecordToBytes(record arrow.Record) ([]byte, error) {
 	var buf bytes.Buffer
 	wr := ipc.NewWriter(&buf, ipc.WithSchema(record.Schema()))


### PR DESCRIPTION
Adds the required record encoding/decoding functions to destination v1 and sourcev2 protocol