### PR TITLE
feat: manageplugin: "go" registry to build before running.

### DIFF
--- a/managedplugin/registry.go
+++ b/managedplugin/registry.go
@@ -11,12 +11,13 @@ type Registry int
 const (
 	RegistryGithub Registry = iota
 	RegistryLocal
+	RegistryGo
 	RegistryGrpc
 	RegistryDocker
 )
 
 func (r Registry) String() string {
-	return [...]string{"github", "local", "grpc", "docker"}[r]
+	return [...]string{"github", "local", "go", "grpc", "docker"}[r]
 }
 
 func (r Registry) MarshalJSON() ([]byte, error) {
@@ -43,6 +44,8 @@ func RegistryFromString(s string) (Registry, error) {
 		return RegistryGithub, nil
 	case "local":
 		return RegistryLocal, nil
+	case "go":
+		return RegistryGo, nil
 	case "grpc":
 		return RegistryGrpc, nil
 	case "docker":

--- a/specs/registry.go
+++ b/specs/registry.go
@@ -11,13 +11,15 @@ type Registry int
 const (
 	RegistryGithub Registry = iota
 	RegistryLocal
+	RegistryGo
 	RegistryGrpc
 	RegistryDocker
 )
 
 func (r Registry) String() string {
-	return [...]string{"github", "local", "grpc", "docker"}[r]
+	return [...]string{"github", "local", "go", "grpc", "docker"}[r]
 }
+
 func (r Registry) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(r.String())
@@ -42,6 +44,8 @@ func RegistryFromString(s string) (Registry, error) {
 		return RegistryGithub, nil
 	case "local":
 		return RegistryLocal, nil
+	case "go":
+		return RegistryGo, nil
 	case "grpc":
 		return RegistryGrpc, nil
 	case "docker":


### PR DESCRIPTION
#### Summary

Instead of a workflow

1. `go build -C ./plugins/destinations/snowflake .`
2. `cloudquery sync ./cloudquery.yml`

with

```yaml
# ./cloudquery.yml
kind: destination
spec:
  name: "snowflake"
  registry: "local"
  path: /home/icio/go/src/github.com/cloudquery/cloudquery/plugins/destination/snowflake/snowflake
```

this change allows for the workflow:

1. `cloudquery sync ./cloudquery.yml`

by changing your config to:

```yaml
# ./cloudquery.yml
kind: destination
spec:
  name: "snowflake"
  registry: "go"
  path: /home/icio/go/src/github.com/cloudquery/cloudquery/plugins/destination/snowflake
```

which will now tell `cloudquery` to run `go build` on the plugin at `path` before running it as if it were `local`.

(path can also be relative to the package)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
