### PR TITLE
fix: Create docker container with Tty true

### DIFF
--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -212,6 +212,7 @@ func (c *Client) startDockerPlugin(ctx context.Context, configPath string) error
 		},
 		Image: configPath,
 		Cmd:   pluginArgs,
+		Tty:   true,
 	}
 	hostConfig := &container.HostConfig{
 		PortBindings: map[nat.Port][]nat.PortBinding{


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/plugin-pb-go/issues/86

See logs https://pkg.go.dev/github.com/docker/docker@v20.10.25+incompatible/client#Client.ContainerLogs

This means we'll only read `stdout` from the container (I think that's OK). If we want both `stderr` we'll need to demultiplex the steam, see 
![image](https://github.com/cloudquery/plugin-pb-go/assets/26760571/1d74a864-bcba-4fd6-ade2-dacf4508a7ea)


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
