### PR TITLE
feat: Add option `WithNoExec()` to skip executing of plugins

### DIFF
--- a/managedplugin/options.go
+++ b/managedplugin/options.go
@@ -22,6 +22,12 @@ func WithNoSentry() Option {
 	}
 }
 
+func WithNoExec() Option {
+	return func(c *Client) {
+		c.noExec = true
+	}
+}
+
 func WithOtelEndpoint(endpoint string) Option {
 	return func(c *Client) {
 		c.otelEndpoint = endpoint


### PR DESCRIPTION
This is required to separate download and execute steps, will help with https://github.com/cloudquery/cloudquery/issues/13937