### PR TITLE
feat: Allow passing an auth token when downloading Hub plugins

### DIFF
--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -114,7 +114,7 @@ func DownloadPluginFromHub(ctx context.Context, authToken string, localPath stri
 	}
 	defer downloadURL.Body.Close()
 	if downloadURL.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("failed to get plugin url for %v %v/%v@%v: plugin version not found. If you're trying to use a paid plugin you might need to run `cloudquery login` first", typ, team, name, version)
+		return fmt.Errorf("failed to get plugin url for %v %v/%v@%v: plugin version not found. If you're trying to use a paid plugin you'll need to run `cloudquery login` first", typ, team, name, version)
 	}
 	if downloadURL.StatusCode == http.StatusTooManyRequests {
 		return fmt.Errorf("failed to get plugin url for %v %v/%v@%v: too many requests. Try logging in via `cloudquery login` to increase rate limits", typ, team, name, version)

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -80,7 +80,7 @@ func getURLLocation(ctx context.Context, org string, name string, version string
 	return "", fmt.Errorf("failed to find plugin %s/%s version %s", org, name, version)
 }
 
-func DownloadPluginFromHub(ctx context.Context, authToken string, localPath string, team string, name string, version string, typ PluginType) error {
+func DownloadPluginFromHub(ctx context.Context, authToken, localPath, team, name, version string, typ PluginType) error {
 	downloadDir := filepath.Dir(localPath)
 	if _, err := os.Stat(localPath); err == nil {
 		return nil

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -34,7 +34,7 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	}
 }
 
-func TestDownloadPluginFromCloudQueryIntegration(t *testing.T) {
+func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 	tmp := t.TempDir()
 	cases := []struct {
 		testName string
@@ -44,11 +44,11 @@ func TestDownloadPluginFromCloudQueryIntegration(t *testing.T) {
 		wantErr  bool
 		typ      PluginType
 	}{
-		{testName: "should download test plugin from cloudquery registry", team: "cloudquery", plugin: "test", version: "v3.1.11", typ: PluginSource},
+		{testName: "should download test plugin from cloudquery registry", team: "cloudquery", plugin: "azuredevops", version: "v3.0.12", typ: PluginSource},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			err := DownloadPluginFromHub(context.Background(), path.Join(tmp, tc.testName), tc.team, tc.plugin, tc.version, tc.typ)
+			err := DownloadPluginFromHub(context.Background(), "", path.Join(tmp, tc.testName), tc.team, tc.plugin, tc.version, tc.typ)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/managedplugin/options.go
+++ b/managedplugin/options.go
@@ -39,3 +39,9 @@ func WithOtelEndpointInsecure() Option {
 		c.otelEndpointInsecure = true
 	}
 }
+
+func WithAuthToken(authToken string) Option {
+	return func(c *Client) {
+		c.authToken = authToken
+	}
+}

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -90,6 +90,7 @@ type Client struct {
 	otelEndpointInsecure bool
 	metrics              *Metrics
 	registry             Registry
+	authToken            string
 }
 
 // typ will be deprecated soon but now required for a transition period
@@ -181,7 +182,7 @@ func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) error {
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
 		c.LocalPath = WithBinarySuffix(c.LocalPath)
-		return DownloadPluginFromHub(ctx, c.LocalPath, org, name, c.config.Version, typ)
+		return DownloadPluginFromHub(ctx, c.authToken, c.LocalPath, org, name, c.config.Version, typ)
 	default:
 		return fmt.Errorf("unknown registry %s", c.config.Registry.String())
 	}

--- a/managedplugin/plugin_test.go
+++ b/managedplugin/plugin_test.go
@@ -56,38 +56,38 @@ func TestManagedPluginCloudQuery(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 	cfg := Config{
-		Name:     "test",
+		Name:     "azuredevops",
 		Registry: RegistryCloudQuery,
-		Path:     "cloudquery/test",
-		Version:  "v3.1.11",
+		Path:     "cloudquery/azuredevops",
+		Version:  "v3.0.12",
 	}
 	clients, err := NewClients(ctx, PluginSource, []Config{cfg}, WithDirectory(tmpDir), WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}
-	testClient := clients.ClientByName("test")
+	testClient := clients.ClientByName("azuredevops")
 	if testClient == nil {
-		t.Fatal("test client not found")
+		t.Fatal("azuredevops client not found")
 	}
 	if err := clients.Terminate(); err != nil {
 		t.Fatal(err)
 	}
-	localPath := filepath.Join(tmpDir, "plugins", PluginSource.String(), "cloudquery", "test", cfg.Version, "plugin")
+	localPath := filepath.Join(tmpDir, "plugins", PluginSource.String(), "cloudquery", "azuredevops", cfg.Version, "plugin")
 	localPath = WithBinarySuffix(localPath)
 	cfg = Config{
-		Name:     "test",
+		Name:     "azuredevops",
 		Registry: RegistryLocal,
 		Path:     localPath,
-		Version:  "v3.1.11",
+		Version:  "v3.0.12",
 	}
 
 	clients, err = NewClients(ctx, PluginSource, []Config{cfg}, WithDirectory(tmpDir), WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}
-	testClient = clients.ClientByName("test")
+	testClient = clients.ClientByName("azuredevops")
 	if testClient == nil {
-		t.Fatal("test client not found")
+		t.Fatal("azuredevops client not found")
 	}
 	if err := clients.Terminate(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/cloudquery-issues/issues/737 (internal issue).
This should unlock paid plugins downloads from the Hub. CLI PR coming in a bit

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
