### PR TITLE
fix: Add `unix://` to connection string for plugins from CloudQuery Hub

### DIFF
--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -210,9 +210,9 @@ func (c *Client) ConnectionString() string {
 	switch c.registry {
 	case RegistryGrpc:
 		return tgt
-	case RegistryLocal:
-		return "unix://" + tgt
-	case RegistryGithub:
+	case RegistryLocal,
+		RegistryGithub,
+		RegistryCloudQuery:
 		return "unix://" + tgt
 	case RegistryDocker:
 		return tgt


### PR DESCRIPTION
Closes https://github.com/cloudquery/cloudquery/issues/15081