### PR TITLE
feat: Use and expose api url env variable

### DIFF
--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -23,11 +23,14 @@ const (
 	DefaultDownloadDir = ".cq"
 	RetryAttempts      = 5
 	RetryWaitTime      = 1 * time.Second
-	envAPIURL          = "CLOUDQUERY_API_URL"
-	apiBaseURL         = "https://api.cloudquery.io"
 )
 
 func APIBaseURL() string {
+	const (
+		envAPIURL  = "CLOUDQUERY_API_URL"
+		apiBaseURL = "https://api.cloudquery.io"
+	)
+
 	if v := os.Getenv(envAPIURL); v != "" {
 		return v
 	}

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -23,8 +23,16 @@ const (
 	DefaultDownloadDir = ".cq"
 	RetryAttempts      = 5
 	RetryWaitTime      = 1 * time.Second
-	APIBaseURL         = "https://api.cloudquery.io"
+	envAPIURL          = "CLOUDQUERY_API_URL"
+	apiBaseURL         = "https://api.cloudquery.io"
 )
+
+func APIBaseURL() string {
+	if v := os.Getenv(envAPIURL); v != "" {
+		return v
+	}
+	return apiBaseURL
+}
 
 // getURLLocation return the URL of the plugin
 // this does a few HEAD requests because we had a few breaking changes to where
@@ -97,7 +105,7 @@ func DownloadPluginFromHub(ctx context.Context, authToken, localPath, team, name
 			return http.ErrUseLastResponse
 		},
 	}
-	c, err := cloudquery_api.NewClient(APIBaseURL, cloudquery_api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+	c, err := cloudquery_api.NewClient(APIBaseURL(), cloudquery_api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 		if authToken != "" {
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		}


### PR DESCRIPTION
Use `CLOUDQUERY_API_URL` for everything. Other consumers can now also use `managedplugin.APIBaseURL()`

Breaking compatibility very briefly (string becomes a func for a cq-internal functionality) so I'm not doing a `feat!`