### PR TITLE
feat: Allow plugins to be downloaded using a user `team_name` context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20231031200323-c49e24273160
 	github.com/avast/retry-go/v4 v4.5.0
-	github.com/cloudquery/cloudquery-api-go v1.4.4
+	github.com/cloudquery/cloudquery-api-go v1.4.5
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231029080147-50d3871d0804 h1:y4EwAGtbzVFz1w9sXggukJmYMVO12925D12Bak7s0vI=
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231029080147-50d3871d0804/go.mod h1:TqWp9yvMb9yZSxFNiij6cmZefm+1jw3oZU0L0w9lT7E=
-github.com/cloudquery/cloudquery-api-go v1.4.4 h1:9VQoRxjWi9/rj1esfL3n6o6OwotoGtCNUAs3onnVwho=
-github.com/cloudquery/cloudquery-api-go v1.4.4/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
+github.com/cloudquery/cloudquery-api-go v1.4.5 h1:nZyHuzodDSZJLjNi12raFpX1ErGACLBehBFN6LZ+d0k=
+github.com/cloudquery/cloudquery-api-go v1.4.5/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -178,17 +178,17 @@ func downloadPluginAssetFromHub(ctx context.Context, authToken, teamName, plugin
 	target := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
 	aj := "application/json"
 
-	switch teamName {
-	case "":
-		resp, err := c.DownloadPluginAssetWithResponse(ctx, pluginTeam, cloudquery_api.PluginKind(typ.String()), name, version, target, &cloudquery_api.DownloadPluginAssetParams{Accept: &aj})
-		if err != nil {
-			return nil, -1, fmt.Errorf("failed to get plugin url: %w", err)
-		}
-		return resp.JSON200, resp.StatusCode(), nil
-	default:
+	switch {
+	case teamName != "":
 		resp, err := c.DownloadPluginAssetByTeamWithResponse(ctx, teamName, pluginTeam, cloudquery_api.PluginKind(typ.String()), name, version, target, &cloudquery_api.DownloadPluginAssetByTeamParams{Accept: &aj})
 		if err != nil {
 			return nil, -1, fmt.Errorf("failed to get plugin url with team: %w", err)
+		}
+		return resp.JSON200, resp.StatusCode(), nil
+	default:
+		resp, err := c.DownloadPluginAssetWithResponse(ctx, pluginTeam, cloudquery_api.PluginKind(typ.String()), name, version, target, &cloudquery_api.DownloadPluginAssetParams{Accept: &aj})
+		if err != nil {
+			return nil, -1, fmt.Errorf("failed to get plugin url: %w", err)
 		}
 		return resp.JSON200, resp.StatusCode(), nil
 	}

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -48,7 +48,15 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			err := DownloadPluginFromHub(context.Background(), "", "", path.Join(tmp, tc.testName), tc.team, tc.plugin, tc.version, tc.typ)
+			err := DownloadPluginFromHub(context.Background(), HubDownloadOptions{
+				LocalPath:     path.Join(tmp, tc.testName),
+				AuthToken:     "",
+				TeamName:      "",
+				PluginTeam:    tc.team,
+				PluginKind:    tc.typ.String(),
+				PluginName:    tc.plugin,
+				PluginVersion: tc.version,
+			})
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -48,7 +48,7 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			err := DownloadPluginFromHub(context.Background(), "", path.Join(tmp, tc.testName), tc.team, tc.plugin, tc.version, tc.typ)
+			err := DownloadPluginFromHub(context.Background(), "", "", path.Join(tmp, tc.testName), tc.team, tc.plugin, tc.version, tc.typ)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/managedplugin/options.go
+++ b/managedplugin/options.go
@@ -45,3 +45,9 @@ func WithAuthToken(authToken string) Option {
 		c.authToken = authToken
 	}
 }
+
+func WithTeamName(teamName string) Option {
+	return func(c *Client) {
+		c.teamName = teamName
+	}
+}

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -91,6 +91,7 @@ type Client struct {
 	metrics              *Metrics
 	registry             Registry
 	authToken            string
+	teamName             string
 }
 
 // typ will be deprecated soon but now required for a transition period
@@ -182,7 +183,7 @@ func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) error {
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
 		c.LocalPath = WithBinarySuffix(c.LocalPath)
-		return DownloadPluginFromHub(ctx, c.authToken, c.LocalPath, org, name, c.config.Version, typ)
+		return DownloadPluginFromHub(ctx, c.authToken, c.teamName, c.LocalPath, org, name, c.config.Version, typ)
 	default:
 		return fmt.Errorf("unknown registry %s", c.config.Registry.String())
 	}

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -183,7 +183,15 @@ func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) error {
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
 		c.LocalPath = WithBinarySuffix(c.LocalPath)
-		return DownloadPluginFromHub(ctx, c.authToken, c.teamName, c.LocalPath, org, name, c.config.Version, typ)
+		return DownloadPluginFromHub(ctx, HubDownloadOptions{
+			AuthToken:     c.authToken,
+			TeamName:      c.teamName,
+			LocalPath:     c.LocalPath,
+			PluginTeam:    org,
+			PluginKind:    typ.String(),
+			PluginName:    name,
+			PluginVersion: c.config.Version,
+		})
 	default:
 		return fmt.Errorf("unknown registry %s", c.config.Registry.String())
 	}


### PR DESCRIPTION
Adding the ability to pass the `team_name` to the download. This will be passed in by the CLI as either the `team_name` in the user's saved configuration (i.e. `cloudquery switch` config) or the `team_name` associated with the API key being used.

Ref: https://github.com/cloudquery/cloudquery-issues/issues/835