### PR TITLE
fix(docker): Check for team and login before proceeding with docker registry download

### DIFF
--- a/managedplugin/docker.go
+++ b/managedplugin/docker.go
@@ -15,6 +15,11 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
+var (
+	ErrLoginRequired = fmt.Errorf("login required")
+	ErrTeamRequired  = fmt.Errorf("team required")
+)
+
 type dockerProgressReader struct {
 	decoder        *json.Decoder
 	bar            *progressbar.ProgressBar
@@ -88,7 +93,13 @@ func pullDockerImage(ctx context.Context, imageName string, authToken string, te
 	// Pull the image
 	additionalHeaders := make(map[string]string)
 	opts := types.ImagePullOptions{}
-	if authToken != "" && strings.HasPrefix(imageName, "docker.cloudquery.io") {
+	if strings.HasPrefix(imageName, "docker.cloudquery.io") {
+		if authToken == "" {
+			return ErrLoginRequired
+		}
+		if teamName == "" {
+			return ErrTeamRequired
+		}
 		namedRef, err := reference.ParseNormalizedNamed(imageName)
 		if err != nil {
 			return fmt.Errorf("failed to parse Docker image tag: %v", err)


### PR DESCRIPTION
This way we can make sure the user doesn't get confusing error messages like:

> error parsing HTTP 400 response body: no error details found in HTTP response body: "{"message":"parameter \"X-Meta-User-Team-Name\" in header has an error: empty value is not allowed","status":400}

or

> unknown: The server could not parse your request body