### PR TITLE
feat: Allow use of CloudQuery registry with docker plugins

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,3 +26,6 @@ jobs:
       - run: go build ./...
       - name: Run tests
         run: make test
+        env:
+          CLOUDQUERY_TEAM_NAME: ${{ secrets.CLOUDQUERY_TEAM_NAME }}
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}

--- a/managedplugin/hub.go
+++ b/managedplugin/hub.go
@@ -1,0 +1,39 @@
+package managedplugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/rs/zerolog"
+)
+
+func getHubClient(logger zerolog.Logger, ops HubDownloadOptions) (*cloudquery_api.ClientWithResponses, error) {
+	c, err := cloudquery_api.NewClientWithResponses(APIBaseURL(),
+		cloudquery_api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			if ops.AuthToken != "" {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ops.AuthToken))
+			}
+			logger.Debug().Interface("ops", ops).Msg(fmt.Sprintf("Requesting %s %s", req.Method, req.URL))
+			return nil
+		}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Hub API client: %w", err)
+	}
+	return c, nil
+}
+
+func isDockerPlugin(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (bool, error) {
+	p, err := c.GetPluginVersionWithResponse(ctx, ops.PluginTeam, cloudquery_api.PluginKind(ops.PluginKind), ops.PluginName, ops.PluginVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to get plugin information: %w", err)
+	}
+	if p.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("failed to get plugin information: %s", p.Status())
+	}
+	if p.JSON200 == nil {
+		return false, fmt.Errorf("failed to get plugin information: response body is empty")
+	}
+	return p.JSON200.PackageType == "docker", nil
+}

--- a/managedplugin/options.go
+++ b/managedplugin/options.go
@@ -57,3 +57,9 @@ func WithLicenseFile(licenseFile string) Option {
 		c.licenseFile = licenseFile
 	}
 }
+
+func WithCloudQueryDockerHost(dockerHost string) Option {
+	return func(c *Client) {
+		c.cqDockerHost = dockerHost
+	}
+}


### PR DESCRIPTION
This change allows Docker plugins to use the CloudQuery registry, meaning that configs can now be written like:

```
path: cloudquery/typeform
version: v1.2.3
```

instead of

```
registry: docker
path: docker.cloudquery.io/cloudquery/source-typeform:v1.2.3
```

The `docker` registry can still be used if preferred, either with or without the `docker.cloudquery.io` path.