### PR TITLE
fix: Enable docker API negotiation

### DIFF
--- a/managedplugin/docker.go
+++ b/managedplugin/docker.go
@@ -71,8 +71,17 @@ func (pr *dockerProgressReader) Read(_ []byte) (n int, err error) {
 	return 0, nil
 }
 
+func newDockerClient(options ...client.Opt) (*client.Client, error) {
+	defaultOptions := []client.Opt{
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+	}
+	options = append(defaultOptions, options...)
+	return client.NewClientWithOpts(options...)
+}
+
 func isDockerImageAvailable(ctx context.Context, imageName string) (bool, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := newDockerClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to create Docker client: %w", err)
 	}
@@ -123,7 +132,7 @@ func pullDockerImage(ctx context.Context, imageName string, authToken string, te
 		opts.RegistryAuth = dockerHubAuth
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHTTPHeaders(additionalHeaders))
+	cli, err := newDockerClient(client.WithHTTPHeaders(additionalHeaders))
 	if err != nil {
 		return fmt.Errorf("failed to create Docker client: %v", err)
 	}

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -268,7 +268,7 @@ func (c *Client) Metrics() Metrics {
 }
 
 func (c *Client) startDockerPlugin(ctx context.Context, configPath string) error {
-	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)
+	cli, err := newDockerClient()
 	if err != nil {
 		return fmt.Errorf("failed to create Docker client: %w", err)
 	}
@@ -640,7 +640,7 @@ func (c *Client) Terminate() error {
 		}()
 	}
 	if c.containerID != "" {
-		cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)
+		cli, err := newDockerClient()
 		if err != nil {
 			return fmt.Errorf("failed to create Docker client: %w", err)
 		}

--- a/managedplugin/plugin_test.go
+++ b/managedplugin/plugin_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	"github.com/docker/docker/client"
 )
 
 func TestManagedPluginGitHub(t *testing.T) {
@@ -97,7 +95,7 @@ func TestManagedPluginCloudQuery(t *testing.T) {
 
 func TestManagedPluginCloudQueryDocker(t *testing.T) {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := newDockerClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +149,7 @@ func TestManagedPluginCloudQueryDocker(t *testing.T) {
 
 func TestManagedPluginDocker(t *testing.T) {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := newDockerClient()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

It seems every time we update the Go Docker SDK it forces users to update their local docker installation too due to API compatibility.
For example the current client version we use is `1.44` but GitHub Actions run on `1.43` so publishing fails:
https://github.com/cloudquery/cloudquery/actions/runs/8155813989/job/22292120213#step:12:12

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
