### PR TITLE
fix: Progressbar handling

### DIFF
--- a/managedplugin/docker.go
+++ b/managedplugin/docker.go
@@ -98,7 +98,7 @@ func isDockerImageAvailable(ctx context.Context, imageName string) (bool, error)
 	return len(images) > 0, nil
 }
 
-func pullDockerImage(ctx context.Context, imageName string, authToken string, teamName string, dockerHubAuth string) error {
+func pullDockerImage(ctx context.Context, imageName string, authToken string, teamName string, dockerHubAuth string, dops DownloaderOptions) error {
 	// Pull the image
 	additionalHeaders := make(map[string]string)
 	opts := image.PullOptions{}
@@ -142,6 +142,14 @@ func pullDockerImage(ctx context.Context, imageName string, authToken string, te
 		return fmt.Errorf("failed to pull Docker image: %v", err)
 	}
 	defer out.Close()
+
+	if dops.NoProgress {
+		_, err = io.Copy(io.Discard, out)
+		if err != nil {
+			return fmt.Errorf("failed to copy image pull output: %v", err)
+		}
+		return nil
+	}
 
 	// Create a progress reader to display the download progress
 	pr := &dockerProgressReader{

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -29,7 +29,7 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	logger := zerolog.Logger{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ)
+			err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
 			if (err != nil) != tc.wantErr {
 				t.Errorf("DownloadPluginFromGithub() error = %v, wantErr %v", err, tc.wantErr)
 				return
@@ -64,7 +64,9 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 				PluginKind:    tc.typ.String(),
 				PluginName:    tc.plugin,
 				PluginVersion: tc.version,
-			})
+			},
+				DownloaderOptions{},
+			)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/managedplugin/options.go
+++ b/managedplugin/options.go
@@ -28,6 +28,12 @@ func WithNoExec() Option {
 	}
 }
 
+func WithNoProgress() Option {
+	return func(c *Client) {
+		c.noProgress = true
+	}
+}
+
 func WithOtelEndpoint(endpoint string) Option {
 	return func(c *Client) {
 		c.otelEndpoint = endpoint


### PR DESCRIPTION
Adds option to skip using progressbar. Since the new progressbar release, writing to the progressbar where the target writer is closed (in our case, `os.Stdout`) produces an error.