### PR TITLE
feat: Expose if plugin was downloaded or cached

### DIFF
--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -131,11 +131,11 @@ type DownloaderOptions struct {
 	NoProgress bool
 }
 
-func DownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) (DownloadSource, error) {
+func DownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) (AssetSource, error) {
 	if _, err := os.Stat(ops.LocalPath); err == nil {
-		return DownloadSourceCached, nil
+		return AssetSourceCached, nil
 	}
-	return DownloadSourceRemote, doDownloadPluginFromHub(ctx, c, ops, dops)
+	return AssetSourceRemote, doDownloadPluginFromHub(ctx, c, ops, dops)
 }
 
 func doDownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) error {
@@ -242,11 +242,11 @@ func downloadPluginAssetFromHub(ctx context.Context, c *cloudquery_api.ClientWit
 	}
 }
 
-func DownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) (DownloadSource, error) {
+func DownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) (AssetSource, error) {
 	if _, err := os.Stat(localPath); err == nil {
-		return DownloadSourceCached, nil
+		return AssetSourceCached, nil
 	}
-	return DownloadSourceRemote, doDownloadPluginFromGithub(ctx, logger, localPath, org, name, version, typ, dops)
+	return AssetSourceRemote, doDownloadPluginFromGithub(ctx, logger, localPath, org, name, version, typ, dops)
 }
 
 func doDownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) error {

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -131,75 +131,78 @@ type DownloaderOptions struct {
 	NoProgress bool
 }
 
-func DownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) (DownloadMode, error) {
-	downloadDir := filepath.Dir(ops.LocalPath)
+func DownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) (DownloadSource, error) {
 	if _, err := os.Stat(ops.LocalPath); err == nil {
-		return DownloadModeCached, nil
+		return DownloadSourceCached, nil
 	}
+	return DownloadSourceRemote, doDownloadPluginFromHub(ctx, c, ops, dops)
+}
 
+func doDownloadPluginFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions, dops DownloaderOptions) error {
+	downloadDir := filepath.Dir(ops.LocalPath)
 	if err := os.MkdirAll(downloadDir, 0755); err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to create plugin directory %s: %w", downloadDir, err)
+		return fmt.Errorf("failed to create plugin directory %s: %w", downloadDir, err)
 	}
 
 	pluginAsset, statusCode, err := downloadPluginAssetFromHub(ctx, c, ops)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to get plugin metadata from hub: %w", err)
+		return fmt.Errorf("failed to get plugin metadata from hub: %w", err)
 	}
 	switch statusCode {
 	case http.StatusOK:
 		// we allow this status code
 	case http.StatusUnauthorized:
-		return DownloadModeRemote, fmt.Errorf("unauthorized. Try logging in via `cloudquery login`")
+		return fmt.Errorf("unauthorized. Try logging in via `cloudquery login`")
 	case http.StatusNotFound:
-		return DownloadModeRemote, fmt.Errorf("failed to download plugin %v %v/%v@%v: plugin version not found. If you're trying to use a private plugin you'll need to run `cloudquery login` first", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion)
+		return fmt.Errorf("failed to download plugin %v %v/%v@%v: plugin version not found. If you're trying to use a private plugin you'll need to run `cloudquery login` first", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion)
 	case http.StatusTooManyRequests:
-		return DownloadModeRemote, fmt.Errorf("too many download requests. Try logging in via `cloudquery login` to increase rate limits")
+		return fmt.Errorf("too many download requests. Try logging in via `cloudquery login` to increase rate limits")
 	default:
-		return DownloadModeRemote, fmt.Errorf("failed to download plugin %v %v/%v@%v: unexpected status code %v", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion, statusCode)
+		return fmt.Errorf("failed to download plugin %v %v/%v@%v: unexpected status code %v", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion, statusCode)
 	}
 	if pluginAsset == nil {
-		return DownloadModeRemote, fmt.Errorf("failed to get plugin metadata from hub for %v %v/%v@%v: missing json response", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion)
+		return fmt.Errorf("failed to get plugin metadata from hub for %v %v/%v@%v: missing json response", ops.PluginKind, ops.PluginTeam, ops.PluginName, ops.PluginVersion)
 	}
 	location := pluginAsset.Location
 	if len(location) == 0 {
-		return DownloadModeRemote, fmt.Errorf("failed to get plugin metadata from hub: empty location from response")
+		return fmt.Errorf("failed to get plugin metadata from hub: empty location from response")
 	}
 	pluginZipPath := ops.LocalPath + ".zip"
 	writtenChecksum, err := downloadFile(ctx, pluginZipPath, location, dops)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to download plugin: %w", err)
+		return fmt.Errorf("failed to download plugin: %w", err)
 	}
 
 	if pluginAsset.Checksum == "" {
 		fmt.Printf("Warning - checksum not verified: %s\n", writtenChecksum)
 	} else if writtenChecksum != pluginAsset.Checksum {
-		return DownloadModeRemote, fmt.Errorf("checksum mismatch: expected %s, got %s", pluginAsset.Checksum, writtenChecksum)
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", pluginAsset.Checksum, writtenChecksum)
 	}
 
 	archive, err := zip.OpenReader(pluginZipPath)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to open plugin archive: %w", err)
+		return fmt.Errorf("failed to open plugin archive: %w", err)
 	}
 	defer archive.Close()
 
 	fileInArchive, err := archive.Open(fmt.Sprintf("plugin-%s-%s-%s-%s", ops.PluginName, ops.PluginVersion, runtime.GOOS, runtime.GOARCH))
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to open plugin archive: %w", err)
+		return fmt.Errorf("failed to open plugin archive: %w", err)
 	}
 
 	out, err := os.OpenFile(ops.LocalPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to create file %s: %w", ops.LocalPath, err)
+		return fmt.Errorf("failed to create file %s: %w", ops.LocalPath, err)
 	}
 	_, err = io.Copy(out, fileInArchive)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to copy body to file: %w", err)
+		return fmt.Errorf("failed to copy body to file: %w", err)
 	}
 	err = out.Close()
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to close file: %w", err)
+		return fmt.Errorf("failed to close file: %w", err)
 	}
-	return DownloadModeRemote, nil
+	return nil
 }
 
 func downloadPluginAssetFromHub(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (*cloudquery_api.PluginAsset, int, error) {
@@ -239,30 +242,33 @@ func downloadPluginAssetFromHub(ctx context.Context, c *cloudquery_api.ClientWit
 	}
 }
 
-func DownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) (DownloadMode, error) {
+func DownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) (DownloadSource, error) {
+	if _, err := os.Stat(localPath); err == nil {
+		return DownloadSourceCached, nil
+	}
+	return DownloadSourceRemote, doDownloadPluginFromGithub(ctx, logger, localPath, org, name, version, typ, dops)
+}
+
+func doDownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localPath string, org string, name string, version string, typ PluginType, dops DownloaderOptions) error {
 	downloadDir := filepath.Dir(localPath)
 	pluginZipPath := localPath + ".zip"
 
-	if _, err := os.Stat(localPath); err == nil {
-		return DownloadModeCached, nil
-	}
-
 	if err := os.MkdirAll(downloadDir, 0755); err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to create plugin directory %s: %w", downloadDir, err)
+		return fmt.Errorf("failed to create plugin directory %s: %w", downloadDir, err)
 	}
 
 	downloadURL, err := getURLLocation(ctx, org, name, version, typ)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to get plugin url: %w", err)
+		return fmt.Errorf("failed to get plugin url: %w", err)
 	}
 	logger.Debug().Msg(fmt.Sprintf("Downloading %s", downloadURL))
 	if _, err := downloadFile(ctx, pluginZipPath, downloadURL, dops); err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to download plugin: %w", err)
+		return fmt.Errorf("failed to download plugin: %w", err)
 	}
 
 	archive, err := zip.OpenReader(pluginZipPath)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to open plugin archive: %w", err)
+		return fmt.Errorf("failed to open plugin archive: %w", err)
 	}
 	defer archive.Close()
 
@@ -281,27 +287,27 @@ func DownloadPluginFromGithub(ctx context.Context, logger zerolog.Logger, localP
 	case strings.HasPrefix(downloadURL, fmt.Sprintf("https://github.com/%s/cq-destination", org)):
 		pathInArchive = fmt.Sprintf("cq-destination-%s", name)
 	default:
-		return DownloadModeRemote, fmt.Errorf("unknown GitHub %s", downloadURL)
+		return fmt.Errorf("unknown GitHub %s", downloadURL)
 	}
 
 	pathInArchive = WithBinarySuffix(pathInArchive)
 	fileInArchive, err := archive.Open(pathInArchive)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to open plugin archive plugins/source/%s: %w", name, err)
+		return fmt.Errorf("failed to open plugin archive plugins/source/%s: %w", name, err)
 	}
 	out, err := os.OpenFile(localPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to create file %s: %w", localPath, err)
+		return fmt.Errorf("failed to create file %s: %w", localPath, err)
 	}
 	_, err = io.Copy(out, fileInArchive)
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to copy body to file: %w", err)
+		return fmt.Errorf("failed to copy body to file: %w", err)
 	}
 	err = out.Close()
 	if err != nil {
-		return DownloadModeRemote, fmt.Errorf("failed to close file: %w", err)
+		return fmt.Errorf("failed to close file: %w", err)
 	}
-	return DownloadModeRemote, nil
+	return nil
 }
 
 func downloadFile(ctx context.Context, localPath string, downloadURL string, dops DownloaderOptions) (string, error) {

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -30,8 +30,8 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			downloadMode, err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
-			if downloadMode != DownloadSourceRemote {
-				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, DownloadSourceRemote)
+			if downloadMode != AssetSourceRemote {
+				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, AssetSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("DownloadPluginFromGithub() error = %v, wantErr %v", err, tc.wantErr)
@@ -70,8 +70,8 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 			},
 				DownloaderOptions{},
 			)
-			if downloadMode != DownloadSourceRemote {
-				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, DownloadSourceRemote)
+			if downloadMode != AssetSourceRemote {
+				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, AssetSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -29,7 +29,10 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	logger := zerolog.Logger{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
+			downloadMode, err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
+			if downloadMode != DownloadModeRemote {
+				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, DownloadModeRemote)
+			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("DownloadPluginFromGithub() error = %v, wantErr %v", err, tc.wantErr)
 				return
@@ -56,7 +59,7 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			err := DownloadPluginFromHub(context.Background(), c, HubDownloadOptions{
+			downloadMode, err := DownloadPluginFromHub(context.Background(), c, HubDownloadOptions{
 				LocalPath:     path.Join(tmp, tc.testName),
 				AuthToken:     "",
 				TeamName:      "",
@@ -67,6 +70,9 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 			},
 				DownloaderOptions{},
 			)
+			if downloadMode != DownloadModeRemote {
+				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, DownloadModeRemote)
+			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -29,9 +29,9 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	logger := zerolog.Logger{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			downloadMode, err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
-			if downloadMode != AssetSourceRemote {
-				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, AssetSourceRemote)
+			assetSource, err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
+			if assetSource != AssetSourceRemote {
+				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", assetSource, AssetSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("DownloadPluginFromGithub() error = %v, wantErr %v", err, tc.wantErr)
@@ -59,7 +59,7 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			downloadMode, err := DownloadPluginFromHub(context.Background(), c, HubDownloadOptions{
+			assetSource, err := DownloadPluginFromHub(context.Background(), c, HubDownloadOptions{
 				LocalPath:     path.Join(tmp, tc.testName),
 				AuthToken:     "",
 				TeamName:      "",
@@ -70,8 +70,8 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 			},
 				DownloaderOptions{},
 			)
-			if downloadMode != AssetSourceRemote {
-				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, AssetSourceRemote)
+			if assetSource != AssetSourceRemote {
+				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", assetSource, AssetSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)

--- a/managedplugin/download_test.go
+++ b/managedplugin/download_test.go
@@ -30,8 +30,8 @@ func TestDownloadPluginFromGithubIntegration(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			downloadMode, err := DownloadPluginFromGithub(context.Background(), logger, path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.typ, DownloaderOptions{})
-			if downloadMode != DownloadModeRemote {
-				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, DownloadModeRemote)
+			if downloadMode != DownloadSourceRemote {
+				t.Errorf("DownloadPluginFromGithub() got = %v, want %v", downloadMode, DownloadSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("DownloadPluginFromGithub() error = %v, wantErr %v", err, tc.wantErr)
@@ -70,8 +70,8 @@ func TestDownloadPluginFromCloudQueryHub(t *testing.T) {
 			},
 				DownloaderOptions{},
 			)
-			if downloadMode != DownloadModeRemote {
-				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, DownloadModeRemote)
+			if downloadMode != DownloadSourceRemote {
+				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() got = %v, want %v", downloadMode, DownloadSourceRemote)
 			}
 			if (err != nil) != tc.wantErr {
 				t.Errorf("TestDownloadPluginFromCloudQueryIntegration() error = %v, wantErr %v", err, tc.wantErr)

--- a/managedplugin/metrics.go
+++ b/managedplugin/metrics.go
@@ -6,48 +6,48 @@ import (
 	"sync/atomic"
 )
 
-type DownloadSource int
+type AssetSource int
 
 const (
-	DownloadSourceUnknown DownloadSource = iota
-	DownloadSourceCached
-	DownloadSourceRemote
+	AssetSourceUnknown AssetSource = iota
+	AssetSourceCached
+	AssetSourceRemote
 )
 
-func (r DownloadSource) String() string {
+func (r AssetSource) String() string {
 	return [...]string{"unknown", "cached", "remote"}[r]
 }
 
-func (r DownloadSource) MarshalJSON() ([]byte, error) {
+func (r AssetSource) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, r.String())), nil
 }
 
-func (r *DownloadSource) UnmarshalJSON(data []byte) (err error) {
+func (r *AssetSource) UnmarshalJSON(data []byte) (err error) {
 	var mode string
 	if err := json.Unmarshal(data, &mode); err != nil {
 		return err
 	}
-	if *r, err = DownloadModeFromString(mode); err != nil {
+	if *r, err = AssetSourceFromString(mode); err != nil {
 		return err
 	}
 	return nil
 }
 
-func DownloadModeFromString(s string) (DownloadSource, error) {
+func AssetSourceFromString(s string) (AssetSource, error) {
 	switch s {
 	case "cached":
-		return DownloadSourceCached, nil
+		return AssetSourceCached, nil
 	case "remote":
-		return DownloadSourceRemote, nil
+		return AssetSourceRemote, nil
 	default:
-		return DownloadSourceUnknown, fmt.Errorf("unknown registry %s", s)
+		return AssetSourceUnknown, fmt.Errorf("unknown mode %s", s)
 	}
 }
 
 type Metrics struct {
-	Errors         uint64
-	Warnings       uint64
-	DownloadSource DownloadSource
+	Errors      uint64
+	Warnings    uint64
+	AssetSource AssetSource
 }
 
 func (m *Metrics) incrementErrors() {

--- a/managedplugin/metrics.go
+++ b/managedplugin/metrics.go
@@ -1,10 +1,57 @@
 package managedplugin
 
-import "sync/atomic"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+)
+
+type DownloadMode int
+
+const (
+	DownloadModeUnknown DownloadMode = iota
+	DownloadModeCached
+	DownloadModeRemote
+)
+
+func (r DownloadMode) String() string {
+	return [...]string{"unknown", "cached", "remote"}[r]
+}
+
+func (r DownloadMode) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(r.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+func (r *DownloadMode) UnmarshalJSON(data []byte) (err error) {
+	var mode string
+	if err := json.Unmarshal(data, &mode); err != nil {
+		return err
+	}
+	if *r, err = DownloadModeFromString(mode); err != nil {
+		return err
+	}
+	return nil
+}
+
+func DownloadModeFromString(s string) (DownloadMode, error) {
+	switch s {
+	case "cached":
+		return DownloadModeCached, nil
+	case "remote":
+		return DownloadModeRemote, nil
+	default:
+		return DownloadModeUnknown, fmt.Errorf("unknown registry %s", s)
+	}
+}
 
 type Metrics struct {
-	Errors   uint64
-	Warnings uint64
+	Errors       uint64
+	Warnings     uint64
+	DownloadMode DownloadMode
 }
 
 func (m *Metrics) incrementErrors() {

--- a/managedplugin/metrics.go
+++ b/managedplugin/metrics.go
@@ -1,32 +1,28 @@
 package managedplugin
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
 )
 
-type DownloadMode int
+type DownloadSource int
 
 const (
-	DownloadModeUnknown DownloadMode = iota
-	DownloadModeCached
-	DownloadModeRemote
+	DownloadSourceUnknown DownloadSource = iota
+	DownloadSourceCached
+	DownloadSourceRemote
 )
 
-func (r DownloadMode) String() string {
+func (r DownloadSource) String() string {
 	return [...]string{"unknown", "cached", "remote"}[r]
 }
 
-func (r DownloadMode) MarshalJSON() ([]byte, error) {
-	buffer := bytes.NewBufferString(`"`)
-	buffer.WriteString(r.String())
-	buffer.WriteString(`"`)
-	return buffer.Bytes(), nil
+func (r DownloadSource) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, r.String())), nil
 }
 
-func (r *DownloadMode) UnmarshalJSON(data []byte) (err error) {
+func (r *DownloadSource) UnmarshalJSON(data []byte) (err error) {
 	var mode string
 	if err := json.Unmarshal(data, &mode); err != nil {
 		return err
@@ -37,21 +33,21 @@ func (r *DownloadMode) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
-func DownloadModeFromString(s string) (DownloadMode, error) {
+func DownloadModeFromString(s string) (DownloadSource, error) {
 	switch s {
 	case "cached":
-		return DownloadModeCached, nil
+		return DownloadSourceCached, nil
 	case "remote":
-		return DownloadModeRemote, nil
+		return DownloadSourceRemote, nil
 	default:
-		return DownloadModeUnknown, fmt.Errorf("unknown registry %s", s)
+		return DownloadSourceUnknown, fmt.Errorf("unknown registry %s", s)
 	}
 }
 
 type Metrics struct {
-	Errors       uint64
-	Warnings     uint64
-	DownloadMode DownloadMode
+	Errors         uint64
+	Warnings       uint64
+	DownloadSource DownloadSource
 }
 
 func (m *Metrics) incrementErrors() {

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -151,8 +151,12 @@ func NewClient(ctx context.Context, typ PluginType, config Config, opts ...Optio
 	for _, opt := range opts {
 		opt(c)
 	}
-	if err := c.downloadPlugin(ctx, typ); err != nil {
+	downloadSource, err := c.downloadPlugin(ctx, typ)
+	if err != nil {
 		return nil, err
+	}
+	if downloadSource != DownloadSourceUnknown {
+		c.metrics.DownloadSource = downloadSource
 	}
 	if !c.noExec {
 		if err := c.execPlugin(ctx); err != nil {
@@ -163,39 +167,36 @@ func NewClient(ctx context.Context, typ PluginType, config Config, opts ...Optio
 	return c, nil
 }
 
-func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) error {
+func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) (DownloadSource, error) {
 	dops := DownloaderOptions{
 		NoProgress: c.noProgress,
 	}
 	switch c.config.Registry {
 	case RegistryGrpc:
-		return nil // GRPC plugins are not downloaded
+		return DownloadSourceUnknown, nil // GRPC plugins are not downloaded
 	case RegistryLocal:
-		return validateLocalExecPath(c.config.Path)
+		return DownloadSourceUnknown, validateLocalExecPath(c.config.Path)
 	case RegistryGithub:
 		pathSplit := strings.Split(c.config.Path, "/")
 		if len(pathSplit) != 2 {
-			return fmt.Errorf("invalid github plugin path: %s. format should be owner/repo", c.config.Path)
+			return DownloadSourceUnknown, fmt.Errorf("invalid github plugin path: %s. format should be owner/repo", c.config.Path)
 		}
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
 		c.LocalPath = WithBinarySuffix(c.LocalPath)
 		downloadMode, err := DownloadPluginFromGithub(ctx, c.logger, c.LocalPath, org, name, c.config.Version, typ, dops)
-		c.metrics.DownloadMode = downloadMode
-		return err
+		return downloadMode, err
 	case RegistryDocker:
 		if imageAvailable, err := isDockerImageAvailable(ctx, c.config.Path); err != nil {
-			c.metrics.DownloadMode = DownloadModeCached
-			return err
+			return DownloadSourceUnknown, err
 		} else if !imageAvailable {
-			c.metrics.DownloadMode = DownloadModeRemote
-			return pullDockerImage(ctx, c.config.Path, c.authToken, c.teamName, c.dockerAuth, dops)
+			return DownloadSourceRemote, pullDockerImage(ctx, c.config.Path, c.authToken, c.teamName, c.dockerAuth, dops)
 		}
-		return nil
+		return DownloadSourceCached, nil
 	case RegistryCloudQuery:
 		pathSplit := strings.Split(c.config.Path, "/")
 		if len(pathSplit) != 2 {
-			return fmt.Errorf("invalid cloudquery plugin path: %s. format should be team/name", c.config.Path)
+			return DownloadSourceUnknown, fmt.Errorf("invalid cloudquery plugin path: %s. format should be team/name", c.config.Path)
 		}
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
@@ -212,28 +213,26 @@ func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) error {
 		}
 		hubClient, err := getHubClient(c.logger, ops)
 		if err != nil {
-			return err
+			return DownloadSourceUnknown, err
 		}
 		isDocker, err := isDockerPlugin(ctx, hubClient, ops)
 		if err != nil {
-			return err
+			return DownloadSourceUnknown, err
 		}
 		if isDocker {
 			path := fmt.Sprintf(c.cqDockerHost+"/%s/%s-%s:%s", ops.PluginTeam, ops.PluginKind, ops.PluginName, ops.PluginVersion)
 			c.config.Registry = RegistryDocker // will be used by exec step
 			c.config.Path = path
 			if imageAvailable, err := isDockerImageAvailable(ctx, path); err != nil {
-				return err
+				return DownloadSourceUnknown, err
 			} else if !imageAvailable {
-				return pullDockerImage(ctx, path, c.authToken, c.teamName, "", dops)
+				return DownloadSourceRemote, pullDockerImage(ctx, path, c.authToken, c.teamName, "", dops)
 			}
-			return nil
+			return DownloadSourceCached, nil
 		}
-		downloadMode, err := DownloadPluginFromHub(ctx, hubClient, ops, dops)
-		c.metrics.DownloadMode = downloadMode
-		return err
+		return DownloadPluginFromHub(ctx, hubClient, ops, dops)
 	default:
-		return fmt.Errorf("unknown registry %s", c.config.Registry.String())
+		return DownloadSourceUnknown, fmt.Errorf("unknown registry %s", c.config.Registry.String())
 	}
 }
 

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -184,8 +184,8 @@ func (c *Client) downloadPlugin(ctx context.Context, typ PluginType) (AssetSourc
 		org, name := pathSplit[0], pathSplit[1]
 		c.LocalPath = filepath.Join(c.directory, "plugins", typ.String(), org, name, c.config.Version, "plugin")
 		c.LocalPath = WithBinarySuffix(c.LocalPath)
-		downloadMode, err := DownloadPluginFromGithub(ctx, c.logger, c.LocalPath, org, name, c.config.Version, typ, dops)
-		return downloadMode, err
+		assetSource, err := DownloadPluginFromGithub(ctx, c.logger, c.LocalPath, org, name, c.config.Version, typ, dops)
+		return assetSource, err
 	case RegistryDocker:
 		if imageAvailable, err := isDockerImageAvailable(ctx, c.config.Path); err != nil {
 			return AssetSourceUnknown, err


### PR DESCRIPTION
#### Summary

Still need to test this. Might not be the cleanest approach.

This should allow the CLI to report plugin downloads

Happy to rename the enum, couldn't think of a better one

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
