### PR TITLE
fix: Delete `invocation_id` log field when streaming plugins logs

### DIFF
--- a/managedplugin/logging.go
+++ b/managedplugin/logging.go
@@ -4,7 +4,9 @@ import "github.com/rs/zerolog"
 
 func (c *Client) jsonToLog(l zerolog.Logger, msg map[string]any) {
 	level := msg["level"]
+	// Delete fields already added by the CLI so that they don't appear twice in the logs when we stream it from plugins
 	delete(msg, "level")
+	delete(msg, "invocation_id")
 	switch level {
 	case "trace":
 		l.Trace().Fields(msg).Msg("")


### PR DESCRIPTION
#### Summary

Part of https://github.com/cloudquery/cloudquery/issues/18443. Both CLI and plugins add the invocation ID field to the log.
When the CLI invokes plugins it streams their logs into its own log so it all shows up in the same file.
This happens here https://github.com/cloudquery/plugin-pb-go/blob/28fae3fab7dd225622fdea542ae67ee5649e8b8c/managedplugin/plugin.go#L480
We parse the log line as JSON, then log it with the CLI logger.
`zerolog` doesn't remove duplicate fields (see https://github.com/rs/zerolog?tab=readme-ov-file#field-duplication ) we need to remove the duplicate ourselves (similar to `level`).
Please note that the duplicates only show up when passing `--log-format json` as it seems the text format does remove duplicates (`zerolog` saves the message to be printed internally in JSON format so probably the conversion to text removes the duplicate somewhere, didn't both to check).

CLI PR in https://github.com/cloudquery/cloudquery/pull/18641

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
