### PR TITLE
refactor: Early return in case of a connection error

### DIFF
--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -484,23 +484,19 @@ func (c *Client) startLocalUnixSocket(ctx context.Context, path string) error {
 	c.wg.Add(1)
 	go c.readLogLines(reader)
 
-	err = c.connectToUnixSocket(ctx)
-	// N.B. we exit early if connecting succeeds here!
-	if err == nil {
-		return nil
+	if err := c.connectToUnixSocket(ctx); err != nil {
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			c.logger.Error().Err(killErr).Msg("failed to kill plugin process")
+		}
+
+		waitErr := cmd.Wait()
+		if waitErr != nil && errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("failed to run plugin %s: %w", path, waitErr)
+		}
+		return fmt.Errorf("failed connecting to plugin %s: %w", path, err)
 	}
 
-	// Error scenarios:
-
-	if killErr := cmd.Process.Kill(); killErr != nil {
-		c.logger.Error().Err(killErr).Msg("failed to kill plugin process")
-	}
-
-	waitErr := cmd.Wait()
-	if waitErr != nil && errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("failed to run plugin %s: %w", path, waitErr)
-	}
-	return fmt.Errorf("failed connecting to plugin %s: %w", path, err)
+	return nil
 }
 
 func (c *Client) getPluginArgs() []string {


### PR DESCRIPTION
#### Summary

The usual pattern in go is to do `if err != nil { // do something }`.
The current code is a bit confusing to read as it does `if err == nil { return err }`.
A smaller change can be to do `if err == nil { return nil }`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
