### PR TITLE
feat: Implement API to get latest plugin version.

### DIFF
--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -411,23 +411,3 @@ func WithBinarySuffix(filePath string) string {
 	}
 	return filePath
 }
-
-func FindLatestPluginVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (string, error) {
-	if ops.TeamName == "" {
-		return "", fmt.Errorf("team name is required to find the latest plugin version")
-	}
-
-	resp, err := c.ListPluginVersionsWithResponse(ctx, ops.PluginTeam, cloudquery_api.PluginKind(ops.PluginKind), ops.PluginName, &cloudquery_api.ListPluginVersionsParams{})
-	if err != nil {
-		return "", fmt.Errorf("failed to list plugin versions: %w", err)
-	}
-	if resp.JSON200 == nil {
-		return "", fmt.Errorf("failed to list plugin versions: %w", err)
-	}
-
-	if len(resp.JSON200.Items) == 0 {
-		return "", fmt.Errorf("no plugin versions found")
-	}
-
-	return resp.JSON200.Items[0].Name, nil
-}

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -412,7 +412,7 @@ func WithBinarySuffix(filePath string) string {
 	return filePath
 }
 
-func findLatestPluginVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (string, error) {
+func FindLatestPluginVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (string, error) {
 	if ops.TeamName == "" {
 		return "", fmt.Errorf("team name is required to find the latest plugin version")
 	}

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -414,7 +414,7 @@ func WithBinarySuffix(filePath string) string {
 
 func findLatestPluginVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (string, error) {
 	if ops.TeamName == "" {
-		return "", nil
+		return "", fmt.Errorf("team name is required to find the latest plugin version")
 	}
 
 	resp, err := c.ListPluginVersionsWithResponse(ctx, ops.PluginTeam, cloudquery_api.PluginKind(ops.PluginKind), ops.PluginName, &cloudquery_api.ListPluginVersionsParams{})

--- a/managedplugin/download.go
+++ b/managedplugin/download.go
@@ -411,3 +411,23 @@ func WithBinarySuffix(filePath string) string {
 	}
 	return filePath
 }
+
+func findLatestPluginVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, ops HubDownloadOptions) (string, error) {
+	if ops.TeamName == "" {
+		return "", nil
+	}
+
+	resp, err := c.ListPluginVersionsWithResponse(ctx, ops.PluginTeam, cloudquery_api.PluginKind(ops.PluginKind), ops.PluginName, &cloudquery_api.ListPluginVersionsParams{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list plugin versions: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return "", fmt.Errorf("failed to list plugin versions: %w", err)
+	}
+
+	if len(resp.JSON200.Items) == 0 {
+		return "", fmt.Errorf("no plugin versions found")
+	}
+
+	return resp.JSON200.Items[0].Name, nil
+}


### PR DESCRIPTION
Prerequisite to fully implement: https://github.com/cloudquery/cloudquery/issues/19286

In order to let CLI users when the plugins they are using are not up to date, we need to now what the latest version is.

This PR only adds this functionality within `plugin-pb-go` within the `managedplugin` module, but it isn't yet used, nor compared to the user's plugin version.

Sample check on CLI to see if it works:

```
$ go run . test-connection /Users/mariano.gappa/Code/test-aws-sync/all.yml

Loading spec(s) from /Users/mariano.gappa/Code/test-aws-sync/all.yml
You chose version v27.23.0. Latest version is v27.23.1.
```

Also note that this implementation errors in a lot of cases, but it is not the intention to actually error to the client; since the purpose is to show a warning, we'll probably elide any warnings (it's debatable) if there's no sufficient information to show a warning.