### PR TITLE
feat: Implement PluginVersionWarner to warn on outdated plugins.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.1
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/cloudquery/cloudquery-api-go v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -14,11 +14,6 @@ github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRS
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-<<<<<<< HEAD
-=======
-github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
-github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
->>>>>>> 0bfc38f (Implement PluginVersionWarner for unauthenticated version checking.)
 github.com/cloudquery/cloudquery-api-go v1.13.1 h1:jU/mpVjgamRXZUWEu+ucNZcLk9OIm5YV6q9B5en5rqQ=
 github.com/cloudquery/cloudquery-api-go v1.13.1/go.mod h1:5oo8HHnv2Y7NgcVvZn59xFlYKJUyeP0tcN8JH3IP2Aw=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
@@ -12,6 +14,11 @@ github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRS
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+<<<<<<< HEAD
+=======
+github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
+github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
+>>>>>>> 0bfc38f (Implement PluginVersionWarner for unauthenticated version checking.)
 github.com/cloudquery/cloudquery-api-go v1.13.1 h1:jU/mpVjgamRXZUWEu+ucNZcLk9OIm5YV6q9B5en5rqQ=
 github.com/cloudquery/cloudquery-api-go v1.13.1/go.mod h1:5oo8HHnv2Y7NgcVvZn59xFlYKJUyeP0tcN8JH3IP2Aw=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
-	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	pbBase "github.com/cloudquery/plugin-pb-go/pb/base/v0"
 	pbDiscovery "github.com/cloudquery/plugin-pb-go/pb/discovery/v0"
 	pbDiscoveryV1 "github.com/cloudquery/plugin-pb-go/pb/discovery/v1"
@@ -685,55 +684,6 @@ func (c *Client) Versions(ctx context.Context) ([]int, error) {
 		res[i] = int(v)
 	}
 	return res, nil
-}
-
-func (c *Client) FindLatestPluginVersion(ctx context.Context, typ PluginType) (string, error) {
-	if c.config.Registry != RegistryCloudQuery {
-		return "", fmt.Errorf("plugin registry is not cloudquery; cannot find latest plugin version")
-	}
-
-	if c.teamName == "" {
-		return "", fmt.Errorf("team name is required to find the latest plugin version")
-	}
-
-	pathSplit := strings.Split(c.config.Path, "/")
-	if len(pathSplit) != 2 {
-		return "", fmt.Errorf("invalid cloudquery plugin path: %s. format should be team/name", c.config.Path)
-	}
-	org, name := pathSplit[0], pathSplit[1]
-
-	if org != "cloudquery" {
-		return "", fmt.Errorf("plugin org is not cloudquery; cannot find latest plugin version")
-	}
-
-	ops := HubDownloadOptions{
-		AuthToken:     c.authToken,
-		TeamName:      c.teamName,
-		LocalPath:     c.LocalPath,
-		PluginTeam:    org,
-		PluginKind:    typ.String(),
-		PluginName:    name,
-		PluginVersion: c.config.Version,
-	}
-	hubClient, err := getHubClient(c.logger, ops)
-	if err != nil {
-		return "", fmt.Errorf("failed to get hub client: %w", err)
-	}
-
-	resp, err := hubClient.GetPluginWithResponse(ctx, ops.PluginTeam, cloudquery_api.PluginKind(ops.PluginKind), ops.PluginName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get plugin: %w", err)
-	}
-
-	if resp.JSON200 == nil {
-		return "", fmt.Errorf("failed to get latest plugin version: %w", err)
-	}
-
-	if resp.JSON200.LatestVersion == nil {
-		return "", nil // It's possible to have no latest version (unpublished plugins)
-	}
-
-	return *resp.JSON200.LatestVersion, nil
 }
 
 func (c *Client) MaxVersion(ctx context.Context) (int, error) {

--- a/managedplugin/version_checker.go
+++ b/managedplugin/version_checker.go
@@ -23,6 +23,9 @@ func NewPluginVersionWarner(logger zerolog.Logger) (*PluginVersionWarner, error)
 }
 
 func (p *PluginVersionWarner) getLatestVersion(ctx context.Context, org string, name string, kind PluginType) (*semver.Version, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin version warner is not initialized")
+	}
 	resp, err := p.hubClient.GetPluginWithResponse(ctx, org, cloudquery_api.PluginKind(kind.String()), name)
 	if err != nil {
 		p.logger.Debug().Str("plugin", name).Err(err).Msg("failed to get plugin info from hub")
@@ -49,7 +52,7 @@ func (p *PluginVersionWarner) getLatestVersion(ctx context.Context, org string, 
 // It returns true if nothing went wrong comparing the versions, and the client's version is outdated; false otherwise.
 func (p *PluginVersionWarner) WarnIfOutdated(ctx context.Context, org string, name string, kind PluginType, actualVersion string) (bool, error) {
 	if p == nil {
-		return false, nil
+		return false, fmt.Errorf("plugin version warner is not initialized")
 	}
 	if actualVersion == "" {
 		return false, nil

--- a/managedplugin/version_checker.go
+++ b/managedplugin/version_checker.go
@@ -26,7 +26,7 @@ func (p *PluginVersionWarner) getLatestVersion(ctx context.Context, org string, 
 	if p == nil {
 		return nil, fmt.Errorf("plugin version warner is not initialized")
 	}
-	if kind != "source" && kind != "destination" && kind != "transformer" {
+	if kind != PluginSource.String() && kind != PluginDestination.String() && kind != PluginTransformer.String() {
 		p.logger.Debug().Str("plugin", name).Str("kind", kind).Msg("invalid kind")
 		return nil, fmt.Errorf("invalid kind: %s", kind)
 	}

--- a/managedplugin/version_checker.go
+++ b/managedplugin/version_checker.go
@@ -48,6 +48,9 @@ func (p *PluginVersionWarner) getLatestVersion(ctx context.Context, org string, 
 // WarnIfOutdated requests the latest version of a plugin from the hub and warns if the client's supplied version is outdated.
 // It returns true if nothing went wrong comparing the versions, and the client's version is outdated; false otherwise.
 func (p *PluginVersionWarner) WarnIfOutdated(ctx context.Context, org string, name string, kind PluginType, actualVersion string) (bool, error) {
+	if p == nil {
+		return false, nil
+	}
 	if actualVersion == "" {
 		return false, nil
 	}

--- a/managedplugin/version_checker.go
+++ b/managedplugin/version_checker.go
@@ -1,0 +1,74 @@
+package managedplugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/rs/zerolog"
+)
+
+type PluginVersionWarner struct {
+	hubClient *cloudquery_api.ClientWithResponses
+	logger    zerolog.Logger
+}
+
+func NewPluginVersionWarner(logger zerolog.Logger) (*PluginVersionWarner, error) {
+	hubClient, err := getHubClient(logger, HubDownloadOptions{}) // Does not use auth token, since API call is public
+	if err != nil {
+		return nil, err
+	}
+	return &PluginVersionWarner{hubClient: hubClient, logger: logger}, nil
+}
+
+func (p *PluginVersionWarner) getLatestVersion(ctx context.Context, org string, name string, kind PluginType) (*semver.Version, error) {
+	resp, err := p.hubClient.GetPluginWithResponse(ctx, org, cloudquery_api.PluginKind(kind.String()), name)
+	if err != nil {
+		p.logger.Debug().Str("plugin", name).Err(err).Msg("failed to get plugin info from hub")
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		p.logger.Debug().Str("plugin", name).Msg("failed to get plugin info from hub, request didn't error but 200 response is nil")
+		return nil, fmt.Errorf("failed to get plugin info from hub, request didn't error but 200 response is nil")
+	}
+	if resp.JSON200.LatestVersion == nil {
+		p.logger.Debug().Str("plugin", name).Msg("cannot check if plugin is outdated, latest version is nil")
+		return nil, fmt.Errorf("cannot check if plugin is outdated, latest version is nil")
+	}
+	latestVersion := *resp.JSON200.LatestVersion
+	latestSemver, err := semver.NewVersion(latestVersion)
+	if err != nil {
+		p.logger.Debug().Str("plugin", name).Str("version", latestVersion).Err(err).Msg("failed to parse latest version")
+		return nil, err
+	}
+	return latestSemver, nil
+}
+
+// WarnIfOutdated requests the latest version of a plugin from the hub and warns if the client's supplied version is outdated.
+// It returns true if nothing went wrong comparing the versions, and the client's version is outdated; false otherwise.
+func (p *PluginVersionWarner) WarnIfOutdated(ctx context.Context, org string, name string, kind PluginType, actualVersion string) (bool, error) {
+	if actualVersion == "" {
+		return false, nil
+	}
+	actualVersionSemver, err := semver.NewVersion(actualVersion)
+	if err != nil {
+		p.logger.Debug().Str("plugin", name).Str("version", actualVersion).Err(err).Msg("failed to parse actual version")
+		return false, err
+	}
+	latestVersionSemver, err := p.getLatestVersion(ctx, org, name, kind)
+	if err != nil {
+		return false, err
+	}
+	if actualVersionSemver.LessThan(latestVersionSemver) {
+		p.logger.Warn().
+			Str("plugin", name).
+			Str("using_version", actualVersionSemver.String()).
+			Str("latest_version", latestVersionSemver.String()).
+			Str("url", fmt.Sprintf("https://hub.cloudquery.io/plugins/%s/%s/%s", kind, org, name)).
+			Msg("Plugin is outdated, consider upgrading to the latest version.")
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/managedplugin/version_checker.go
+++ b/managedplugin/version_checker.go
@@ -14,8 +14,8 @@ type PluginVersionWarner struct {
 	logger    zerolog.Logger
 }
 
-func NewPluginVersionWarner(logger zerolog.Logger) (*PluginVersionWarner, error) {
-	hubClient, err := getHubClient(logger, HubDownloadOptions{}) // Does not use auth token, since API call is public
+func NewPluginVersionWarner(logger zerolog.Logger, optionalAuthToken string) (*PluginVersionWarner, error) {
+	hubClient, err := getHubClient(logger, HubDownloadOptions{AuthToken: optionalAuthToken})
 	if err != nil {
 		return nil, err
 	}

--- a/managedplugin/version_checker_test.go
+++ b/managedplugin/version_checker_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPluginVersionWarnerUnknownPluginFails(t *testing.T) {
-	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop(), "")
 	require.NoError(t, err)
 	warned, err := versionWarner.WarnIfOutdated(context.Background(), "unknown", "unknown", "source", "1.0.0")
 	assert.Error(t, err)
@@ -19,7 +19,7 @@ func TestPluginVersionWarnerUnknownPluginFails(t *testing.T) {
 
 // Note: this is an integration test that requires Internet access and the hub to be running
 func TestPluginLatestVersionDoesNotWarn(t *testing.T) {
-	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop(), "")
 	require.NoError(t, err)
 	latestVersion, err := versionWarner.getLatestVersion(context.Background(), "cloudquery", "aws", "source")
 	assert.NoError(t, err)
@@ -31,7 +31,7 @@ func TestPluginLatestVersionDoesNotWarn(t *testing.T) {
 // Note: this is an integration test that requires Internet access and the hub to be running
 // CloudQuery's aws source plugin must exist in the hub, and be over version v1.0.0
 func TestPluginLatestVersionWarns(t *testing.T) {
-	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop(), "")
 	require.NoError(t, err)
 	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", "source", "v1.0.0")
 	assert.NoError(t, err)

--- a/managedplugin/version_checker_test.go
+++ b/managedplugin/version_checker_test.go
@@ -1,0 +1,39 @@
+package managedplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginVersionWarnerUnknownPluginFails(t *testing.T) {
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	require.NoError(t, err)
+	warned, err := versionWarner.WarnIfOutdated(context.Background(), "unknown", "unknown", PluginSource, "1.0.0")
+	assert.Error(t, err)
+	assert.False(t, warned)
+}
+
+// Note: this is an integration test that requires Internet access and the hub to be running
+func TestPluginLatestVersionDoesNotWarn(t *testing.T) {
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	require.NoError(t, err)
+	latestVersion, err := versionWarner.getLatestVersion(context.Background(), "cloudquery", "aws", PluginSource)
+	assert.NoError(t, err)
+	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", PluginSource, latestVersion.String())
+	assert.NoError(t, err)
+	assert.False(t, hasWarned)
+}
+
+// Note: this is an integration test that requires Internet access and the hub to be running
+// CloudQuery's aws source plugin must exist in the hub, and be over version v1.0.0
+func TestPluginLatestVersionWarns(t *testing.T) {
+	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
+	require.NoError(t, err)
+	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", PluginSource, "v1.0.0")
+	assert.NoError(t, err)
+	assert.True(t, hasWarned)
+}

--- a/managedplugin/version_checker_test.go
+++ b/managedplugin/version_checker_test.go
@@ -12,7 +12,7 @@ import (
 func TestPluginVersionWarnerUnknownPluginFails(t *testing.T) {
 	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
 	require.NoError(t, err)
-	warned, err := versionWarner.WarnIfOutdated(context.Background(), "unknown", "unknown", PluginSource, "1.0.0")
+	warned, err := versionWarner.WarnIfOutdated(context.Background(), "unknown", "unknown", "source", "1.0.0")
 	assert.Error(t, err)
 	assert.False(t, warned)
 }
@@ -21,9 +21,9 @@ func TestPluginVersionWarnerUnknownPluginFails(t *testing.T) {
 func TestPluginLatestVersionDoesNotWarn(t *testing.T) {
 	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
 	require.NoError(t, err)
-	latestVersion, err := versionWarner.getLatestVersion(context.Background(), "cloudquery", "aws", PluginSource)
+	latestVersion, err := versionWarner.getLatestVersion(context.Background(), "cloudquery", "aws", "source")
 	assert.NoError(t, err)
-	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", PluginSource, latestVersion.String())
+	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", "source", latestVersion.String())
 	assert.NoError(t, err)
 	assert.False(t, hasWarned)
 }
@@ -33,7 +33,7 @@ func TestPluginLatestVersionDoesNotWarn(t *testing.T) {
 func TestPluginLatestVersionWarns(t *testing.T) {
 	versionWarner, err := NewPluginVersionWarner(zerolog.Nop())
 	require.NoError(t, err)
-	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", PluginSource, "v1.0.0")
+	hasWarned, err := versionWarner.WarnIfOutdated(context.Background(), "cloudquery", "aws", "source", "v1.0.0")
 	assert.NoError(t, err)
 	assert.True(t, hasWarned)
 }


### PR DESCRIPTION
The previous iteration of this PR (https://github.com/cloudquery/plugin-pb-go/pull/415) had some non-ideal feedback:
- It might require a CLI login unnecessarily.
- Uses a brand new semver strategy, instead of using the one we use in the backend.

This implementation makes sure to not use any auth, and reuses the SemVer library we already use (although not in this repo).

It also warns already, rather than sending the version to the client for bespoke warnings, making it more lightweight for the client. Example use should be:

```
versionWarner, err := managedplugin.NewPluginVersionWarner(logger)
if err != nil {
  // Could decide to ignore this error
}

didWarn, err := versionWarner.WarnIfOutdated(ctx, "cloudquery", "aws", usingVersion)

// Ignore both return values, since warning should be best effort, but it still issues debug logs for errors
// Should not fail if versionWarner == nil due to above error
```

**Note** I tested with integration tests, let me know if I should mock API for them