### PR TITLE
fix: Reset logger context when streaming logs from plugins

### DIFF
--- a/managedplugin/logging.go
+++ b/managedplugin/logging.go
@@ -4,7 +4,7 @@ import "github.com/rs/zerolog"
 
 func (c *Client) jsonToLog(l zerolog.Logger, msg map[string]any) {
 	level := msg["level"]
-	// Delete fields already added by the CLI so that they don't appear twice in the logs when we stream it from plugins
+	// The log level is part of the log message received from the plugin, so we need to remove it before logging
 	delete(msg, "level")
 	switch level {
 	case "trace":

--- a/managedplugin/logging.go
+++ b/managedplugin/logging.go
@@ -6,7 +6,6 @@ func (c *Client) jsonToLog(l zerolog.Logger, msg map[string]any) {
 	level := msg["level"]
 	// Delete fields already added by the CLI so that they don't appear twice in the logs when we stream it from plugins
 	delete(msg, "level")
-	delete(msg, "invocation_id")
 	switch level {
 	case "trace":
 		l.Trace().Fields(msg).Msg("")

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -548,6 +548,8 @@ func (c *Client) getPluginArgs() []string {
 func (c *Client) readLogLines(reader io.ReadCloser) {
 	defer c.wg.Done()
 	lr := NewLogReader(reader)
+	// reset the context to avoid duplicate fields in the logs when streaming logs from plugins
+	pluginsLogger := c.logger.With().Reset().Timestamp().Logger()
 	for {
 		line, err := lr.NextLine()
 		if errors.Is(err, io.EOF) {
@@ -565,7 +567,7 @@ func (c *Client) readLogLines(reader io.ReadCloser) {
 		if err := json.Unmarshal(line, &structuredLogLine); err != nil {
 			c.logger.Info().Str("level", "unknown").Msg(string(line))
 		} else {
-			c.jsonToLog(c.logger, structuredLogLine)
+			c.jsonToLog(pluginsLogger, structuredLogLine)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/2624 (internal issue)

We were using the logger created here https://github.com/cloudquery/cloudquery/blob/69143a73499660db2ab714781a5d207884fb9303/cli/cmd/logging.go#L51 to output logs messages from plugins. Plugins already set their log context in https://github.com/cloudquery/plugin-sdk/blob/8b9e067af19604d90d2e77d6e1aff1d93adad752/plugin/plugin.go#L213 and https://github.com/cloudquery/plugin-sdk/blob/8b9e067af19604d90d2e77d6e1aff1d93adad752/plugin/plugin.go#L241, so when we stream them to the `cloudquery.log` file we should use a new logger with an empty context.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
