### PR TITLE
feat: Add errored tables to metrics.

### DIFF
--- a/managedplugin/logging.go
+++ b/managedplugin/logging.go
@@ -18,6 +18,9 @@ func (c *Client) jsonToLog(l zerolog.Logger, msg map[string]any) {
 		c.metrics.incrementWarnings()
 	case "error":
 		l.Error().Fields(msg).Msg("")
+		if msg["message"].(string) == "table resolver finished with error" && msg["table"].(string) != "" {
+			c.metrics.addErroredTable(msg["table"].(string))
+		}
 		c.metrics.incrementErrors()
 	default:
 		l.Error().Fields(msg).Msg("unknown level")

--- a/managedplugin/metrics.go
+++ b/managedplugin/metrics.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
+
+	"github.com/cloudquery/plugin-pb-go/metrics/set"
 )
 
 type AssetSource int
@@ -45,9 +47,10 @@ func AssetSourceFromString(s string) (AssetSource, error) {
 }
 
 type Metrics struct {
-	Errors      uint64
-	Warnings    uint64
-	AssetSource AssetSource
+	Errors        uint64
+	Warnings      uint64
+	AssetSource   AssetSource
+	ErroredTables *set.SyncSortedStringSet
 }
 
 func (m *Metrics) incrementErrors() {
@@ -56,4 +59,11 @@ func (m *Metrics) incrementErrors() {
 
 func (m *Metrics) incrementWarnings() {
 	atomic.AddUint64(&m.Warnings, 1)
+}
+
+func (m *Metrics) addErroredTable(table string) {
+	if m.ErroredTables == nil {
+		m.ErroredTables = set.NewSyncSortedStringSet()
+	}
+	m.ErroredTables.Add(table)
 }

--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -277,9 +277,10 @@ func (c *Client) ConnectionString() string {
 
 func (c *Client) Metrics() Metrics {
 	return Metrics{
-		Errors:      atomic.LoadUint64(&c.metrics.Errors),
-		Warnings:    atomic.LoadUint64(&c.metrics.Warnings),
-		AssetSource: c.metrics.AssetSource,
+		Errors:        atomic.LoadUint64(&c.metrics.Errors),
+		Warnings:      atomic.LoadUint64(&c.metrics.Warnings),
+		AssetSource:   c.metrics.AssetSource,
+		ErroredTables: c.metrics.ErroredTables,
 	}
 }
 

--- a/metrics/set/sync_sorted_string_set.go
+++ b/metrics/set/sync_sorted_string_set.go
@@ -1,0 +1,43 @@
+package set
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// SyncSortedStringSet is a concurrency-safe sorted set of strings.
+//
+// - Use `Add` to add a string to the set.
+// - Use `Get` to get a comma-separated, sorted string of all the strings in the set.
+type SyncSortedStringSet struct {
+	mu     sync.Mutex
+	tables map[string]struct{}
+}
+
+func NewSyncSortedStringSet() *SyncSortedStringSet {
+	return &SyncSortedStringSet{
+		tables: make(map[string]struct{}),
+	}
+}
+
+func (e *SyncSortedStringSet) Add(table string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.tables[table] = struct{}{}
+}
+
+func (e *SyncSortedStringSet) Get() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	keys := make([]string, 0, len(e.tables))
+	for k := range e.tables {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return strings.Join(keys, ",")
+}

--- a/metrics/set/sync_sorted_string_set.go
+++ b/metrics/set/sync_sorted_string_set.go
@@ -21,6 +21,7 @@ func NewSyncSortedStringSet() *SyncSortedStringSet {
 	}
 }
 
+// Add adds a string to the set.
 func (e *SyncSortedStringSet) Add(table string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -28,7 +29,12 @@ func (e *SyncSortedStringSet) Add(table string) {
 	e.tables[table] = struct{}{}
 }
 
+// Get returns a comma-separated, sorted string of all the strings in the set.
 func (e *SyncSortedStringSet) Get() string {
+	if e == nil {
+		return ""
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 

--- a/metrics/set/sync_sorted_string_set.go
+++ b/metrics/set/sync_sorted_string_set.go
@@ -11,22 +11,22 @@ import (
 // - Use `Add` to add a string to the set.
 // - Use `Get` to get a comma-separated, sorted string of all the strings in the set.
 type SyncSortedStringSet struct {
-	mu     sync.Mutex
-	tables map[string]struct{}
+	mu      sync.Mutex
+	strings map[string]struct{}
 }
 
 func NewSyncSortedStringSet() *SyncSortedStringSet {
 	return &SyncSortedStringSet{
-		tables: make(map[string]struct{}),
+		strings: make(map[string]struct{}),
 	}
 }
 
 // Add adds a string to the set.
-func (e *SyncSortedStringSet) Add(table string) {
+func (e *SyncSortedStringSet) Add(str string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	e.tables[table] = struct{}{}
+	e.strings[str] = struct{}{}
 }
 
 // Get returns a comma-separated, sorted string of all the strings in the set.
@@ -38,8 +38,8 @@ func (e *SyncSortedStringSet) Get() string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	keys := make([]string, 0, len(e.tables))
-	for k := range e.tables {
+	keys := make([]string, 0, len(e.strings))
+	for k := range e.strings {
 		keys = append(keys, k)
 	}
 


### PR DESCRIPTION
Currently, the sync doesn't propagate the list of tables whose resolvers failed during a sync, except via logs on the source side.

This PR propagates the list via Metrics by consuming these logs.

Note that this solution only works if the CLI starts the plugins (e.g. doesn't work on `grpc`), because otherwise CLI doesn't have access to the plugin's stderr. In that case, the metrics will still propagate the list within these process' bounds, but no one will be able to use them.

This is an example AWS sync showcasing the final ErroredTables field propagated via SyncSummaries (will need a very small monorepo PR)

<img width="1406" alt="Screenshot 2024-12-18 at 10 38 36" src="https://github.com/user-attachments/assets/3e09743f-fa6f-4a56-a6ae-c6278231a76e" />
<img width="555" alt="Screenshot 2024-12-18 at 10 38 43" src="https://github.com/user-attachments/assets/599fc813-332e-4f75-a9b6-f0524f5ca249" />
