### PR TITLE
fix: Use Docker SDK to configure  port binding

### DIFF
--- a/managedplugin/plugin.go
+++ b/managedplugin/plugin.go
@@ -297,7 +297,7 @@ func (c *Client) startDockerPlugin(ctx context.Context, configPath string) error
 	}
 
 	if len(portMappings) == 0 {
-		return fmt.Errorf("failed to parse port spec: %w", errors.New("no port bindings found"))
+		return fmt.Errorf("failed to parse port spec: %w", errors.New("no port mappings found"))
 	}
 
 	portMapping := portMappings[0]


### PR DESCRIPTION
#### Summary

While testing https://github.com/cloudquery/cloudquery/pull/21179 I noticed syncing with docker plugins stopped working (even before https://github.com/cloudquery/cloudquery/pull/21179).

Looks like the host port is not mapped correctly (probably due to changes with recent docker engines), so the CLI can't connect to the plugin gRPC server.

This PR fixes the issue by using the Docker SDK to get the port binding from a string value, ensuring the mapping is done correctly (hopefully for future versions as well)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt ./...` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
